### PR TITLE
Implement Windows EBS Watcher Startup and enable Windows EBS Discovery UTs

### DIFF
--- a/agent/app/agent_windows.go
+++ b/agent/app/agent_windows.go
@@ -25,6 +25,7 @@ import (
 	asmfactory "github.com/aws/amazon-ecs-agent/agent/asm/factory"
 	"github.com/aws/amazon-ecs-agent/agent/data"
 	"github.com/aws/amazon-ecs-agent/agent/dockerclient/dockerapi"
+	ebs "github.com/aws/amazon-ecs-agent/agent/ebs"
 	"github.com/aws/amazon-ecs-agent/agent/ecscni"
 	"github.com/aws/amazon-ecs-agent/agent/engine"
 	"github.com/aws/amazon-ecs-agent/agent/engine/dockerstate"
@@ -105,7 +106,11 @@ func (agent *ecsAgent) startEBSWatcher(
 	taskEngine engine.TaskEngine,
 	dockerClient dockerapi.DockerClient,
 ) {
-	seelog.Debug("Windows EBS Watcher not implemented: No Op")
+	if agent.ebsWatcher == nil {
+		seelog.Debug("Creating new EBS watcher...")
+		agent.ebsWatcher = ebs.NewWatcher(agent.ctx, state, taskEngine, dockerClient)
+		go agent.ebsWatcher.Start()
+	}
 }
 
 // handler implements https://godoc.org/golang.org/x/sys/windows/svc#Handler

--- a/ecs-agent/api/attachment/resource/ebs_discovery_windows_test.go
+++ b/ecs-agent/api/attachment/resource/ebs_discovery_windows_test.go
@@ -31,7 +31,6 @@ const (
 )
 
 func TestParseExecutableOutputWithHappyPath(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -44,7 +43,6 @@ func TestParseExecutableOutputWithHappyPath(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithMissingDiskNumber(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -56,7 +54,6 @@ func TestParseExecutableOutputWithMissingDiskNumber(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithMissingVolumeInformation(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -68,7 +65,6 @@ func TestParseExecutableOutputWithMissingVolumeInformation(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithMissingDeviceName(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -80,7 +76,6 @@ func TestParseExecutableOutputWithMissingDeviceName(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithVolumeNameMismatch(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -93,7 +88,6 @@ func TestParseExecutableOutputWithVolumeNameMismatch(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithDeviceNameMismatch(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := fmt.Sprintf("Disk Number: 0\r\n"+
 		"Volume ID: vol-abcdef1234567890a\r\n"+
 		"Device Name: sda1\r\n\r\n"+
@@ -106,7 +100,6 @@ func TestParseExecutableOutputWithDeviceNameMismatch(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithTruncatedOutputBuffer(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := "Disk Number: 0\r\n" +
 		"Volume ID: vol-abcdef1234567890a\r\n" +
 		"Device Name: sda1\r\n\r\n" +
@@ -118,7 +111,6 @@ func TestParseExecutableOutputWithTruncatedOutputBuffer(t *testing.T) {
 }
 
 func TestParseExecutableOutputWithUnexpectedOutput(t *testing.T) {
-	t.Skip("Skipping timeout test. Still needs to be fixed.")
 	output := "No EBS NVMe disks found."
 	parsedOutput, err := parseExecutableOutput([]byte(output), testVolumeID, deviceName)
 	require.Error(t, err, "cannot find the volume ID: %s", output)


### PR DESCRIPTION
### Summary
Enable Windows EBS Watcher Startup and enable the UTs for Windows EBS Discovery. The implementation for Windows EBS Discovery is already present.

### Implementation details
Call `ebs.NewWatcher` in `watcher.go` for `agent_windows.go`

### Testing
CP for Windows EBS TA is not fully implemented yet. Mocked a sample payload in agent startup functionality and saw the following log in `ecs-agent.log`

```
agent.startEBSWatcher(state, taskEngine, agent.dockerClient)

tempAttachmentProperties := map[string]string{
	apiebs.ResourceTypeName:        apiebs.ElasticBlockStorage,
	apiebs.VolumeIdName:            "vol-06a9cf692fc9f4bc4",
	apiebs.FargateResourceIdName:   "resourceID",
	apiebs.VolumeSizeInGiBName:     "50",
	apiebs.RequestedSizeName:       "20",
	apiebs.FileSystemTypeName:      "NTFS",
	apiebs.VolumeIdKey:             "vol-06a9cf692fc9f4bc4",
	apiebs.VolumeSizeGibKey:        "50",
	apiebs.DeviceNameKey:           "xvde",
	apiebs.SourceVolumeHostPathKey: "/testPath",
	apiebs.VolumeNameKey:           "test",
	apiebs.FileSystemKey:           "NTFS",
}

duration := time.Now().Add(2000000 * time.Millisecond)

go agent.ebsWatcher.HandleResourceAttachment(&apiebs.ResourceAttachment{
	AttachmentInfo: attachment.AttachmentInfo{
		AttachmentARN:        "dummy-arn",
		Status:               attachment.AttachmentNone,
		ExpiresAt:            duration,
		AttachStatusSent:     false,
		ClusterARN:           "dummy-cluster-arn",
		ContainerInstanceARN: "dummy-container-instance-arn",
	},
	AttachmentProperties: tempAttachmentProperties,
})
```
```
level=info time=2024-05-17T21:15:56Z msg="found volume with volumeID: vol-06a9cf692fc9f4bc4 and deviceName: xvde" module=ebs_discovery_windows.go
```

New tests cover the changes: yes

### Description for the changelog
Implement Windows EBS Watcher Startup

**Does this PR include breaking model changes? If so, Have you added transformation functions?**
N/A

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
